### PR TITLE
Add -t option to only show tracked files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
 
   -V, --version   output the version number
   -m, --modified  only show modified files
+  -t, --tracked   only show tracked files
   -h, --help      output usage information
 ```
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ program
   .version(version)
   .usage('[options] [dir]')
   .option('-m, --modified', 'only show modified files')
+  .option('-t, --tracked', 'only show tracked files')
   .parse(process.argv)
 
 gitree(program.args[0] || '.')
@@ -45,7 +46,7 @@ async function gitree (p) {
     return
   }
 
-  const nodes = await buildNodes(files, gitStatuses, p)
+  const nodes = await buildNodes(files, gitStatuses, p, program.tracked)
   const tree = buildTree(nodes, p)
   printTree(tree)
 }

--- a/utils/buildNodes.js
+++ b/utils/buildNodes.js
@@ -1,16 +1,20 @@
 const path = require('path')
 const getGitRoot = require('./getGitRoot')
 
-async function buildNodes (files, statuses, p) {
+async function buildNodes (files, statuses, p, trackedOnly) {
   const gitRoot = await getGitRoot(p)
 
-  files = files.map((file) => {
+  files = files.reduce((list, file) => {
     const ret = {
       to: path.join(gitRoot, file),
       from: null
     }
 
     if (statuses[file]) {
+      if (trackedOnly && [statuses[file].x, statuses[file].y].includes('?')) {
+        return list
+      }
+
       if (statuses[file].from) {
         ret.from = path.join(gitRoot, statuses[file].from)
       }
@@ -21,11 +25,17 @@ async function buildNodes (files, statuses, p) {
       delete statuses[file]
     }
 
-    return ret
-  })
+    list.push(ret)
+
+    return list
+  }, [])
 
   if (Object.keys(statuses).length) {
     Object.keys(statuses).forEach((status) => {
+      if (trackedOnly && [statuses[status].x, statuses[status].y].includes('?')) {
+        return
+      }
+
       files.push({
         to: path.join(gitRoot, statuses[status].to),
         from: statuses[status].from ? path.join(gitRoot, statuses[status].from) : null,


### PR DESCRIPTION
This adds `-t` (or `--tracked`), meaning the output won't show any files marked as `untracked`.

This is useful to see general diff trees without test/local files getting in the way.