### PR TITLE
-I flag for filtering

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,12 +1,9 @@
 name: Node.js Package
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
-    branches:
-      - master
+    tags:
+      - '*'
 
 jobs:
   build:
@@ -28,7 +25,7 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
@@ -41,7 +38,9 @@ jobs:
         with:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
-          scope: '@your-github-username'
-      - run: npm publish
+          scope: '@jpwilliams'
+      - name: 'publish to gpr'
+        run: |
+          npm publish --registry=https://npm.pkg.github.com/jpwilliams --scope=@jpwilliams
         env:
-          NODE_AUTH_TOKEN: ${{secrets.github_package_token}}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ Like Git, `gitree` only tracks _files_, so empty directories will never be liste
 
 # What does it show?
 
-`gitree` shows any files that your repository's `.gitignore` files allows you to see, marking them with useful statuses:
-
-![Statuses](https://user-images.githubusercontent.com/1736957/29529312-12082cbc-8697-11e7-9d3e-a11f9bbb0d12.png)
+`gitree` shows any files that your repository's `.gitignore` files allows you to see, marking them with useful statuses like the ones in the screenshot above.
 
 # What if it's not a Git repository?
 
@@ -39,10 +37,11 @@ Usage: gitree [options] [dir]
 
 Options:
 
-  -V, --version   output the version number
-  -m, --modified  only show modified files
-  -t, --tracked   only show tracked files
-  -h, --help      output usage information
+  -V, --version           output the version number
+  -m, --modified          only show modified files
+  -t, --tracked           only show tracked files
+  -I, --ignore <pattern>  do not list files that match the given pattern
+  -h, --help              output usage information
 ```
 
 # Can it get any cooler?

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# gitree
+# @jpwilliams/gitree
 
 Print a directory tree that shows Git status and ignores files dictated by `.gitignore`.
 
 ``` sh
-$ npm i -g gitree
+$ npm i -g @jpwilliams/gitree
 $ gitree
 
 # OR
 
-$ npx gitree
+$ npx @jpwilliams/gitree
 ```
 
 ![Example](https://user-images.githubusercontent.com/1736957/29526963-3e3c8178-868f-11e7-875f-a15364a49cf9.png)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ $ gitree
 $ npx @jpwilliams/gitree
 ```
 
-![Example](https://user-images.githubusercontent.com/1736957/29526963-3e3c8178-868f-11e7-875f-a15364a49cf9.png)
+<p align="center">
+  <img width="750" height="491" src="https://user-images.githubusercontent.com/1736957/65135842-8783e780-d9fe-11e9-887b-3e04381795ac.png">
+</p>
 
 # What?
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ program
   .usage('[options] [dir]')
   .option('-m, --modified', 'only show modified files')
   .option('-t, --tracked', 'only show tracked files')
-  .option('-I, --ignore <pattern>', 'do not list files that match the given glob pattern', collect, [])
+  .option('-I, --ignore <pattern>', 'do not list files that match the given pattern', collect, [])
   .parse(process.argv)
 
 gitree(program.args[0] || '.')

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ const {
   buildTree,
   filesFromGitStatus,
   printTree,
-  getGitLineChanges
+  getGitLineChanges,
+  collect
 } = microloader('.', {
   objectify: true,
   cwd: path.join(__dirname, 'utils')
@@ -23,6 +24,7 @@ program
   .usage('[options] [dir]')
   .option('-m, --modified', 'only show modified files')
   .option('-t, --tracked', 'only show tracked files')
+  .option('-I, --ignore <pattern>', 'do not list files that match the given glob pattern', collect, [])
   .parse(process.argv)
 
 gitree(program.args[0] || '.')
@@ -60,6 +62,6 @@ async function gitree (p) {
   }
 
   const nodes = await buildNodes(files, gitStatuses, gitLineChanges, p, program.tracked)
-  const tree = buildTree(nodes, p)
+  const tree = buildTree(nodes, p, program.ignore)
   printTree(tree)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gitree",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "^1.9.0"
       }
     },
     "balanced-match": {
@@ -22,7 +22,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -31,9 +31,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
       "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
       }
     },
     "color-convert": {
@@ -41,7 +41,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -64,9 +64,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "escape-string-regexp": {
@@ -79,13 +79,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "fs.realpath": {
@@ -103,12 +103,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "has-flag": {
@@ -116,13 +116,18 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
+    "ignore": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -150,8 +155,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "microloader": {
@@ -159,8 +164,8 @@
       "resolved": "https://registry.npmjs.org/microloader/-/microloader-0.4.2.tgz",
       "integrity": "sha1-zlkDxndl8JGZaW0zceRCgX0gEJs=",
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4"
+        "glob": "^7.1.1",
+        "lodash": "^4.17.4"
       }
     },
     "minimatch": {
@@ -168,7 +173,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "npm-run-path": {
@@ -176,7 +181,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "once": {
@@ -184,7 +189,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "p-finally": {
@@ -217,7 +222,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -240,7 +245,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "which": {
@@ -248,7 +253,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gitree",
+  "name": "@jpwilliams/gitree",
   "version": "1.2.0",
   "description": "Print a directory tree that shows Git status and ignores files dictated by .gitignore.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chalk": "^2.1.0",
     "commander": "^2.11.0",
     "execa": "^0.8.0",
+    "ignore": "^5.1.4",
     "microloader": "^0.4.2",
     "parse-git-status": "^0.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jpwilliams/gitree",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Print a directory tree that shows Git status and ignores files dictated by .gitignore.",
   "main": "index.js",
   "scripts": {

--- a/utils/buildTree.js
+++ b/utils/buildTree.js
@@ -1,13 +1,23 @@
 const path = require('path')
+const ignore = require('ignore')
 const getFileTarget = require('./getFileTarget')
 
-function buildTree (nodes, p) {
+function buildTree (nodes, p, ignorePattern) {
+  const ig = ignore()
+  if (ignorePattern) ig.add(ignorePattern)
+
   const isAbsolute = path.isAbsolute(p)
   const basePath = isAbsolute ? p : path.join(process.cwd(), p)
 
   const parsedNodes = nodes
     .reduce((nodes, node, i) => {
       const calculatedPath = path.relative(basePath, node.to)
+
+      if (ignorePattern) {
+        const shouldBeIgnored = ig.ignores(calculatedPath)
+        if (shouldBeIgnored) return nodes
+      }
+
       const fakePath = calculatedPath
 
       const split = fakePath.split(path.sep)

--- a/utils/collect.js
+++ b/utils/collect.js
@@ -1,0 +1,5 @@
+function collect (value, previous) {
+	return previous.concat([value])
+}
+
+module.exports = collect

--- a/utils/printTree.js
+++ b/utils/printTree.js
@@ -14,15 +14,34 @@ function printTree (tree, level = 0, prefix = '') {
         line += node.name
       } else {
         if (node.x === 'A') {
-          line += chalk.green(node.name) + (node.hasOwnProperty('added') ? ` ${chalk.green(`+${node.added}`)} ${chalk.red(`-${node.deleted}`)}` : '') + chalk.dim(' (new file)')
+          line
+            += chalk.green(node.name)
+            + (node.added ? ` ${chalk.green(`+${node.added}`)}` : '')
+            + (node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '')
+            + chalk.dim(' (new file)')
         } else if (node.x === 'M' || node.y === 'M') {
-          line += chalk.yellow(node.name) + (node.hasOwnProperty('added') ? ` ${chalk.green(`+${node.added}`)} ${chalk.red(`-${node.deleted}`)}` : '')
+          line
+            += chalk.yellow(node.name)
+            + (node.added ? ` ${chalk.green(`+${node.added}`)}` : '')
+            + (node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '')
         } else if (node.y === 'D' || node.x === 'D') {
-          line += chalk.red(node.name) + (node.hasOwnProperty('added') ? ` ${chalk.green(`+${node.added}`)} ${chalk.red(`-${node.deleted}`)}` : '') + chalk.dim(' (deleted)')
+          line
+            += chalk.red(node.name)
+            + (node.added ? ` ${chalk.green(`+${node.added}`)}` : '')
+            + (node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '')
+            + chalk.dim(' (deleted)')
         } else if (node.x === 'R') {
-          line += chalk.yellow.italic(node.name) + (node.hasOwnProperty('added') ? ` ${chalk.green(`+${node.added}`)} ${chalk.red(`-${node.deleted}`)}` : '') + chalk.dim(` (renamed from "${path.relative(path.dirname(node.to), node.from)}")`)
+          line
+            += chalk.yellow.italic(node.name)
+            + (node.added ? ` ${chalk.green(`+${node.added}`)}` : '')
+            + (node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '')
+            + chalk.dim(` (renamed from "${path.relative(path.dirname(node.to), node.from)}")`)
         } else if (node.x === '?' || node.y === '?') {
-          line += chalk.dim(node.name) + (node.hasOwnProperty('added') ? ` ${chalk.green(`+${node.added}`)} ${chalk.red(`-${node.deleted}`)}` : '') + chalk.dim(' (untracked)')
+          line
+            += chalk.dim(node.name)
+            + (node.added ? ` ${chalk.green(`+${node.added}`)}` : '')
+            + (node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '')
+            + chalk.dim(' (untracked)')
         }
       }
     }


### PR DESCRIPTION
Addresses #13.

A few libraries utilise `|` to separate patterns when specifying similar things, though through testing I'd frequently accidentally pipe the command, so we're going to go for multiple flag uses instead.

The requirement from #13 was to be able to do something like the following to filter out `a`, `b`, and `c`.
```
gt --filter a b c
```

With this PR, the equivalent would be:
```
gt -I a -I b -I c
```

We're utilising the [ignore](https://www.npmjs.com/package/ignore) package here, so the patterns given should be able to use anything a `.gitignore` file does which keeps us in line with the functionality of the utility. For example, I could filter out all `.js` files using `*.js`.