### PR TITLE
New --collapse option for reducing vertical space on sparse modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Options:
   -V, --version           output the version number
   -m, --modified          only show modified files
   -t, --tracked           only show tracked files
+  -c, --collapse          collapse directory nodes that contain a single child
   -I, --ignore <pattern>  do not list files that match the given pattern
   -h, --help              output usage information
 ```

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ program
 	.usage('[options] [dir]')
 	.option('-m, --modified', 'only show modified files')
 	.option('-t, --tracked', 'only show tracked files')
+	.option('-c, --collapse', 'collapse directory nodes that contain a single child')
 	.option('-I, --ignore <pattern>', 'do not list files that match the given pattern', collect, [])
 	.parse(process.argv)
 
@@ -64,5 +65,5 @@ async function gitree (p) {
 
 	const nodes = await buildNodes(files, gitStatuses, gitLineChanges, p, program.tracked)
 	const tree = buildTree(nodes, p, program.ignore)
-	printTree(tree)
+	printTree(tree, program.collapse)
 }

--- a/utils/printTree.js
+++ b/utils/printTree.js
@@ -1,63 +1,64 @@
 const chalk = require('chalk')
 const path = require('path')
 
+function makeLine (node) {
+	let line = ''
+
+	if (node.type === 'directory') {
+		line += chalk.bold.blue(node.name)
+	} else {
+		if (!node.x && !node.y) {
+			line += node.name
+		} else {
+			if (node.x === 'A') {
+				line +=
+					chalk.green(node.name) +
+					(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
+					(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '') +
+					chalk.dim(' (new file)')
+			} else if (node.x === 'M' || node.y === 'M') {
+				line +=
+					chalk.yellow(node.name) +
+					(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
+					(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '')
+			} else if (node.y === 'D' || node.x === 'D') {
+				line +=
+					chalk.red(node.name) +
+					(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
+					(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '') +
+					chalk.dim(' (deleted)')
+			} else if (node.x === 'R') {
+				line +=
+					chalk.yellow.italic(node.name) +
+					(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
+					(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '') +
+					chalk.dim(` (renamed from "${path.relative(path.dirname(node.to), node.from)}")`)
+			} else if (node.x === '?' || node.y === '?') {
+				line +=
+					chalk.dim(node.name) +
+					(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
+					(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '') +
+					chalk.dim(' (untracked)')
+			}
+		}
+	}
+
+	return line
+}
+
 function printTree (tree, collapse, level = 0, prefix = '') {
 	const len = tree.length - 1
 
-	function makeLine(node) {
-		let line = ''
-	
-		if (node.type === 'directory') {
-			line += chalk.bold.blue(node.name)
-		} else {
-			if (!node.x && !node.y) {
-				line += node.name
-			} else {
-				if (node.x === 'A') {
-					line +=
-						chalk.green(node.name) +
-						(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
-						(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '') +
-						chalk.dim(' (new file)')
-				} else if (node.x === 'M' || node.y === 'M') {
-					line +=
-						chalk.yellow(node.name) +
-						(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
-						(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '')
-				} else if (node.y === 'D' || node.x === 'D') {
-					line +=
-						chalk.red(node.name) +
-						(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
-						(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '') +
-						chalk.dim(' (deleted)')
-				} else if (node.x === 'R') {
-					line +=
-						chalk.yellow.italic(node.name) +
-						(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
-						(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '') +
-						chalk.dim(` (renamed from "${path.relative(path.dirname(node.to), node.from)}")`)
-				} else if (node.x === '?' || node.y === '?') {
-					line +=
-						chalk.dim(node.name) +
-						(node.added ? ` ${chalk.green(`+${node.added}`)}` : '') +
-						(node.deleted ? ` ${chalk.red(`-${node.deleted}`)}` : '') +
-						chalk.dim(' (untracked)')
-				}
-			}
-		}
-		return line;
-	}
-
 	tree.forEach((node, i) => {
-
 		let line = makeLine(node)
 
 		const pointer = level > 0 ? (len > 0 ? (i === len ? '└── ' : '├── ') : (level ? '└── ' : '')) : ''
 
-		while (collapse && node.contents && node.contents.length == 1)
-		{
-			node = node.contents[0]
-			line += '/' + makeLine(node)
+		if (collapse) {
+			while (node.contents && node.contents.length === 1) {
+				node = node.contents[0]
+				line += path.sep + makeLine(node)
+			}
 		}
 
 		console.log(prefix + pointer + line)

--- a/utils/printTree.js
+++ b/utils/printTree.js
@@ -1,12 +1,12 @@
 const chalk = require('chalk')
 const path = require('path')
 
-function printTree (tree, level = 0, prefix = '') {
+function printTree (tree, collapse, level = 0, prefix = '') {
 	const len = tree.length - 1
 
-	tree.forEach((node, i) => {
+	function makeLine(node) {
 		let line = ''
-
+	
 		if (node.type === 'directory') {
 			line += chalk.bold.blue(node.name)
 		} else {
@@ -45,8 +45,20 @@ function printTree (tree, level = 0, prefix = '') {
 				}
 			}
 		}
+		return line;
+	}
+
+	tree.forEach((node, i) => {
+
+		let line = makeLine(node)
 
 		const pointer = level > 0 ? (len > 0 ? (i === len ? '└── ' : '├── ') : (level ? '└── ' : '')) : ''
+
+		while (collapse && node.contents && node.contents.length == 1)
+		{
+			node = node.contents[0]
+			line += '/' + makeLine(node)
+		}
 
 		console.log(prefix + pointer + line)
 
@@ -54,7 +66,7 @@ function printTree (tree, level = 0, prefix = '') {
 			let newPrefix = prefix
 			if (level) newPrefix += `${i === len ? ' ' : '│'}   `
 
-			printTree(node.contents, level + 1, newPrefix)
+			printTree(node.contents, collapse, level + 1, newPrefix)
 		}
 	})
 }


### PR DESCRIPTION
In some of my projects I edit files from all kinds of different folders, and so the tree structure can sometimes be too verbose. To accommodate this kind of "sparse editing" I added a --collapse option that will avoid tree-rendering nodes that only have one child. It's best said with pictures.

Before:
![image](https://user-images.githubusercontent.com/964720/68853383-8ca1a200-06e2-11ea-9406-001a6ed17857.png)

After: 
![image](https://user-images.githubusercontent.com/964720/68853361-7dbaef80-06e2-11ea-900f-c567fb8f3392.png)
